### PR TITLE
Make it easier to cross-compile, by using x/text/encoding

### DIFF
--- a/encodedbytes/reader.go
+++ b/encodedbytes/reader.go
@@ -67,7 +67,7 @@ func (r *Reader) ReadRestString(encoding byte) (string, error) {
 		return "", err
 	}
 
-	return Decoders[encoding].ConvertString(string(b))
+	return Decoders[encoding].String(string(b))
 }
 
 // Read a null terminated string of specified encoding
@@ -81,7 +81,7 @@ func (r *Reader) ReadNullTermString(encoding byte) (string, error) {
 	if -1 == atIndex {
 		return "", errors.New("could not read null terminated string")
 	}
-	return Decoders[encoding].ConvertString(string(b[:atIndex]))
+	return Decoders[encoding].String(string(b[:atIndex]))
 }
 
 func NewReader(b []byte) *Reader { return &Reader{b, 0} }

--- a/encodedbytes/util_test.go
+++ b/encodedbytes/util_test.go
@@ -56,12 +56,12 @@ func TestEncodeDecode(t *testing.T) {
 	expectedUTF8 := "hêllo wørld"
 
 	idx := IndexForEncoding("ISO-8859-1")
-	decoded, err := Decoders[idx].ConvertString(string(sampleISO_8859_1))
+	decoded, err := Decoders[idx].String(string(sampleISO_8859_1))
 	require.NoError(t, err)
 	assert.Equal(t, expectedUTF8, decoded)
 
 	// Try round-tripping it, and compare with original.
-	encoded, err := Encoders[idx].ConvertString(decoded)
+	encoded, err := Encoders[idx].String(decoded)
 	require.NoError(t, err)
 	assert.Equal(t, string(sampleISO_8859_1), encoded)
 }

--- a/encodedbytes/util_test.go
+++ b/encodedbytes/util_test.go
@@ -6,6 +6,9 @@ package encodedbytes
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSynch(t *testing.T) {
@@ -30,4 +33,35 @@ func TestNorm(t *testing.T) {
 	if result := NormBytes(normResult); !bytes.Equal(result, norm) {
 		t.Errorf("encodedbytes.NormBytes(%d) = %v, want %v", normResult, result, norm)
 	}
+}
+
+func TestIndexes(t *testing.T) {
+	// Encodings, in index order
+	encodings := []string{
+		"ISO-8859-1", "UTF-16", "UTF-16BE", "UTF-8",
+	}
+	for i, e := range encodings {
+		idx := IndexForEncoding(e)
+		assert.Equal(t, byte(i), idx)
+
+		name := EncodingForIndex(byte(i))
+		assert.Equal(t, e, name)
+	}
+}
+
+// Verify that ISO-8859-1 can be decoded and encoded.
+func TestEncodeDecode(t *testing.T) {
+	// hêllo wørld (e-circumflex in hello, o-slash in world)
+	sampleISO_8859_1 := []byte{0x68, 0xea, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0xf8, 0x72, 0x6c, 0x64}
+	expectedUTF8 := "hêllo wørld"
+
+	idx := IndexForEncoding("ISO-8859-1")
+	decoded, err := Decoders[idx].ConvertString(string(sampleISO_8859_1))
+	require.NoError(t, err)
+	assert.Equal(t, expectedUTF8, decoded)
+
+	// Try round-tripping it, and compare with original.
+	encoded, err := Encoders[idx].ConvertString(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, string(sampleISO_8859_1), encoded)
 }

--- a/encodedbytes/writer.go
+++ b/encodedbytes/writer.go
@@ -36,7 +36,7 @@ func (w *Writer) WriteByte(b byte) (err error) {
 }
 
 func (w *Writer) WriteString(s string, encoding byte) (err error) {
-	encodedString, err := Encoders[encoding].ConvertString(s)
+	encodedString, err := Encoders[encoding].String(s)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/richdawe/id3-go
 
 go 1.20
 
-require github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da // indirect
+require (
+	github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da
+	github.com/stretchr/testify v1.8.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/richdawe/id3-go
 go 1.20
 
 require (
-	github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/text v0.10.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/richdawe/id3-go
+
+go 1.20
+
+require github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da h1:0qwwqQCLOOXPl58ljnq3sTJR7yRuMolM02vjxDh4ZVE=
+github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da/go.mod h1:ns+zIWBBchgfRdxNgIJWn2x6U95LQchxeqiN5Cgdgts=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da h1:0qwwqQCLOOXPl58ljnq3sTJR7yRuMolM02vjxDh4ZVE=
-github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da/go.mod h1:ns+zIWBBchgfRdxNgIJWn2x6U95LQchxeqiN5Cgdgts=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/text v0.10.0 h1:UpjohKhiEgNc0CSauXmwYftY1+LlaC75SJwh0SgCX58=
+golang.org/x/text v0.10.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da h1:0qwwqQCLOOXPl58ljnq3sTJR7yRuMolM02vjxDh4ZVE=
 github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da/go.mod h1:ns+zIWBBchgfRdxNgIJWn2x6U95LQchxeqiN5Cgdgts=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/id3.go
+++ b/id3.go
@@ -5,9 +5,10 @@ package id3
 
 import (
 	"errors"
-	"github.com/mikkyang/id3-go/v1"
-	"github.com/mikkyang/id3-go/v2"
 	"os"
+
+	v1 "github.com/richdawe/id3-go/v1"
+	v2 "github.com/richdawe/id3-go/v2"
 )
 
 const (

--- a/id3_test.go
+++ b/id3_test.go
@@ -5,11 +5,12 @@ package id3
 
 import (
 	"bytes"
-	v2 "github.com/mikkyang/id3-go/v2"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	v2 "github.com/richdawe/id3-go/v2"
 )
 
 const (

--- a/v1/id3v1.go
+++ b/v1/id3v1.go
@@ -4,9 +4,10 @@
 package v1
 
 import (
-	v2 "github.com/mikkyang/id3-go/v2"
 	"io"
 	"os"
+
+	v2 "github.com/richdawe/id3-go/v2"
 )
 
 const (

--- a/v2/frame.go
+++ b/v2/frame.go
@@ -6,7 +6,8 @@ package v2
 import (
 	"errors"
 	"fmt"
-	"github.com/mikkyang/id3-go/encodedbytes"
+
+	"github.com/richdawe/id3-go/encodedbytes"
 )
 
 const (

--- a/v2/id3v2.go
+++ b/v2/id3v2.go
@@ -5,9 +5,10 @@ package v2
 
 import (
 	"fmt"
-	"github.com/mikkyang/id3-go/encodedbytes"
 	"io"
 	"os"
+
+	"github.com/richdawe/id3-go/encodedbytes"
 )
 
 const (

--- a/v2/id3v22.go
+++ b/v2/id3v22.go
@@ -4,8 +4,9 @@
 package v2
 
 import (
-	"github.com/mikkyang/id3-go/encodedbytes"
 	"io"
+
+	"github.com/richdawe/id3-go/encodedbytes"
 )
 
 const (

--- a/v2/id3v23.go
+++ b/v2/id3v23.go
@@ -4,8 +4,9 @@
 package v2
 
 import (
-	"github.com/mikkyang/id3-go/encodedbytes"
 	"io"
+
+	"github.com/richdawe/id3-go/encodedbytes"
 )
 
 var (


### PR DESCRIPTION
[iconv-go](https://github.com/djimenez/iconv-go) links to the iconv library. This prevents me from cross-compiling on Linux to e.g.: Mac OS X. [golang's x/text](https://pkg.go.dev/golang.org/x/text) actually supports similar features to iconv in its `x/text/encoding` modules. Use x/text instead of iconv-go.